### PR TITLE
Adjust background image styling to prevent tiling

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
     <title>Skatman</title>
   </head>
-  <body class="bg-[url('/img/bg2.jpg')] bg-cover bg-center bg-no-repeat">
+  <body class="min-h-screen bg-[url('/img/bg2.jpg')] bg-cover bg-center bg-no-repeat bg-fixed">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
     <title>Skatman</title>
   </head>
-  <body class="bg-cover bg-center bg-[url('/img/bg2.jpg')]">
+  <body class="bg-[url('/img/bg2.jpg')] bg-cover bg-center bg-no-repeat">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>


### PR DESCRIPTION
### Motivation
- Ensure the landing page background image does not tile and retains a pleasant appearance across viewports.
- Preserve the existing cover and center behavior while preventing the image from repeating.
- Keep the change minimal and limited to static markup/CSS utility classes.

### Description
- Updated the `body` element in `index.html` to include `bg-no-repeat` alongside `bg-cover` and `bg-center` and the `bg-[url('/img/bg2.jpg')]` utility.
- This prevents the background from repeating while keeping it centered and scaled to cover the viewport.
- No other files were modified.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite served the app successfully.
- Ran a Playwright script to load the page and capture a screenshot which produced an artifact (`artifacts/skatman-bg.png`).
- No automated unit tests were added or modified for this visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662bc4b18c833290bbc524eed69a62)